### PR TITLE
Fix checkbox styles

### DIFF
--- a/lib/moon/components/checkbox.ex
+++ b/lib/moon/components/checkbox.ex
@@ -11,14 +11,24 @@ defmodule Moon.Components.Checkbox do
     ~F"""
     {asset_import(@socket, "js/components/checkbox")}
 
-    <label class={"inline-flex items-center mt-3 #{@class}"}>
+    <label class={"relative inline-flex items-center mt-3 #{@class}"}>
       <input
         type="checkbox"
         checked={@checked}
         disabled={@disabled}
-        class="border disabled:text-hit-120 disabled:border-trunks-100 border-solid border-beerus-100 text-piccolo-100 focus:ring-transparent"
+        class="border disabled:text-hit-120  border-solid
+               border-trunks-100 disabled:border-beerus-100 text-piccolo-100 cursor-pointer focus:ring-transparent
+               whitespace-nowrap overflow-hidden"
       />
-      <span class="moon-checkbox-caption">
+      <span class="ml-[var(--space--default)] text-trunks-100 cursor-pointer inline-block before:after:m-space-default
+                after:m-space-default before:transition-duration-default
+                after:before:transition-duration-default before:ease-linear after:ease-linear
+                before:bg-goku-40 before:rounded-full before:opacity-0 before:transform-none
+                after:bg-transparent after:transition-colors before:left-0 after:left-0
+                transition before:transition-default after:transition-default
+                before:ease-in after:ease-in before:w-[var(--space--default)] after:w-[var(--space--default)]
+                before:h-[var(--space--default)] after:h-[var(--space--default)]
+                before:absolute after:absolute">
         <#slot />
       </span>
     </label>

--- a/lib/moon_web/pages/components/checkbox_page.ex
+++ b/lib/moon_web/pages/components/checkbox_page.ex
@@ -1,6 +1,5 @@
 defmodule MoonWeb.Pages.Components.CheckboxPage do
   use MoonWeb, :live_view
-  alias Moon.Components.Stack
   alias Moon.Components.Checkbox
   alias Moon.Components.CodePreview
   alias Moon.Autolayouts.TopToDown
@@ -31,20 +30,16 @@ defmodule MoonWeb.Pages.Components.CheckboxPage do
       <Heading size={16}>Checkbox</Heading>
       <ExampleAndCode>
         <:example>
-          <Stack>
-            <Checkbox>
-              I agree to receive bonus & marketing emails.
-            </Checkbox>
-          </Stack>
+          <Checkbox>
+            I agree to receive bonus & marketing emails.
+          </Checkbox>
         </:example>
 
         <:code>
           <#CodePreview>
-      <Stack>
         <Checkbox>
           I agree to receive bonus & marketing emails.
         </Checkbox>
-      </Stack>
     </#CodePreview>
         </:code>
       </ExampleAndCode>
@@ -52,20 +47,16 @@ defmodule MoonWeb.Pages.Components.CheckboxPage do
       <Heading size={16}>Disabled</Heading>
       <ExampleAndCode>
         <:example>
-          <Stack>
-            <Checkbox disabled="true">
-              I agree to receive bonus & marketing emails.
-            </Checkbox>
-          </Stack>
+          <Checkbox disabled="true">
+            I agree to receive bonus & marketing emails.
+          </Checkbox>
         </:example>
 
         <:code>
           <#CodePreview>
-      <Stack>
         <Checkbox disabled="true">
           I agree to receive bonus & marketing emails.
         </Checkbox>
-      </Stack>
     </#CodePreview>
         </:code>
       </ExampleAndCode>
@@ -73,20 +64,16 @@ defmodule MoonWeb.Pages.Components.CheckboxPage do
       <Heading size={16}>Selected Disabled</Heading>
       <ExampleAndCode>
         <:example>
-          <Stack>
-            <Checkbox disabled="true" checked="true">
-              I agree to receive bonus & marketing emails.
-            </Checkbox>
-          </Stack>
+          <Checkbox disabled="true" checked="true">
+            I agree to receive bonus & marketing emails.
+          </Checkbox>
         </:example>
 
         <:code>
           <#CodePreview>
-      <Stack>
         <Checkbox disabled="true" checked="true">
           I agree to receive bonus & marketing emails.
         </Checkbox>
-      </Stack>
     </#CodePreview>
         </:code>
       </ExampleAndCode>
@@ -94,20 +81,16 @@ defmodule MoonWeb.Pages.Components.CheckboxPage do
       <Heading size={16}>Checked</Heading>
       <ExampleAndCode>
         <:example>
-          <Stack>
-            <Checkbox checked="true">
-              I agree to receive bonus & marketing emails.
-            </Checkbox>
-          </Stack>
+          <Checkbox checked="true">
+            I agree to receive bonus & marketing emails.
+          </Checkbox>
         </:example>
 
         <:code>
           <#CodePreview>
-      <Stack>
         <Checkbox checked="true">
           I agree to receive bonus & marketing emails.
         </Checkbox>
-      </Stack>
     </#CodePreview>
         </:code>
       </ExampleAndCode>


### PR DESCRIPTION
Add tailwind classes to replace `moon-checkbox-caption` 