### PR TITLE
Remove variants configuration

### DIFF
--- a/assets/tailwind.config.js
+++ b/assets/tailwind.config.js
@@ -104,18 +104,6 @@ module.exports = {
       hover: 'rgba(0, 0, 0, 0.08)',
     },
   },
-  variants: {
-    dataError: ["focus"],
-    extend: {
-      scale: ['group-hover'],
-      borderWidth: ['group-hover', 'last'],
-      boxShadow: ['invalid'],
-      backgroundColor: ['checked'],
-      borderColor: ['checked'],
-      textColor: ['disabled'],
-      width: ['hover', 'focus']
-    },
-  },
   plugins: [
     require('@tailwindcss/aspect-ratio'),
     require('@tailwindcss/forms'),


### PR DESCRIPTION
With JIT mode https://tailwindcss.com/docs/just-in-time-mode, variants configuration is used. So removing them in this PR.

![image](https://user-images.githubusercontent.com/266/130619799-67297f4d-4c3a-41a0-a059-bbb0454615db.png)
