### PR TITLE
Update Phoenix version

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -9,7 +9,7 @@ defmodule Moon.MixProject do
       version: @version,
       elixir: "~> 1.11",
       elixirc_paths: elixirc_paths(Mix.env()),
-      compilers: [:phoenix, :gettext] ++ Mix.compilers(),
+      compilers: [:gettext] ++ Mix.compilers(),
       start_permanent: Mix.env() == :prod,
       aliases: aliases(),
       deps: deps(),
@@ -42,7 +42,7 @@ defmodule Moon.MixProject do
   # Type `mix help deps` for examples and options.
   defp deps do
     [
-      {:phoenix, "~> 1.5.10"},
+      {:phoenix, "~> 1.5.12"},
       {:phoenix_live_view, "~> 0.15.7"},
       {:phoenix_html, "~> 2.11"},
       {:phoenix_live_dashboard, "~> 0.3 or ~> 0.2.9"},


### PR DESCRIPTION
- As per https://twitter.com/elixirphoenix/status/1438222537301843970, "If you are running Elixir v1.11+ and Phoenix v1.5.12+, you no longer need `:phoenix` in the list of compilers in your mix.exs. This should speed up mix CLI times considerably for large projects!"
- mix.lock is already locked with Phoenix 1.5.12 so not added in the PR