### PR TITLE
Automate changelog updates

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,18 +19,22 @@ jobs:
         with:
           node-version: 14
 
-      - name: Set up Conventional Commit preset
+      - name: Install Semantic Release, plugins and preset
         working-directory: .
-        run: npm install conventional-changelog-conventionalcommits
+        run: |
+          npm install -g \
+            semantic-release@18.0.0 \
+            @semantic-release/git@10.0.0 \
+            @semantic-release/changelog@6.0.0 \
+            conventional-changelog-conventionalcommits@4.6.1
 
-      - name: Set version and  release
-        id: semver
+      - name: Run Sematic Release
         working-directory: .
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: npx semantic-release@17
+        run: semantic-release
 
-      # Get release version
+      # Get new release version
       - name: Get release tag
         id: release-tag
         uses: WyriHaximus/github-action-get-previous-tag@v1.1

--- a/.releaserc
+++ b/.releaserc
@@ -10,6 +10,17 @@
       { "preset": "conventionalcommits" }
     ],
     [
+      "@semantic-release/changelog",
+      { "changelogFile": "CHANGELOG.md" }
+    ],
+    [
+      "@semantic-release/git",
+      { 
+        "assets": ["CHANGELOG.md"],
+        "message": "chore(release ${nextRelease.version}): update changelog"
+      }
+    ],
+    [
       "@semantic-release/github",
       { "addReleases": true }
     ]


### PR DESCRIPTION
This uses `@semantic-release/changelog` and `@semantic-release/git` to update `CHANGELOG.md` on every new release. 

- Thanks to @v0idpwn  for [pointing this plugin](https://github.com/coingaming/moon/pull/149#issuecomment-928917119) :) 
- I've tested this in a private repo, a `CHANGELOG.md` will be created on next release and it will be automatically updated on every release from then onwards
- This closes PR #149  

