### PR TITLE
feat(components/tabs.ex): tabs with url patch

### DIFF
--- a/lib/moon/components/tabs.ex
+++ b/lib/moon/components/tabs.ex
@@ -22,8 +22,10 @@ defmodule Moon.Components.Tabs.TabLink do
 
   use Moon.StatelessComponent
   alias Surface.Components.Link
+  alias Surface.Components.LivePatch
 
   prop(active, :boolean, default: false)
+  prop(patch, :boolean, default: false)
   prop(to, :any)
   prop(on_click, :event)
   prop(item_id, :string)
@@ -31,14 +33,23 @@ defmodule Moon.Components.Tabs.TabLink do
 
   def render(assigns) do
     ~F"""
-    <Link
-      to={@to}
-      class={"inline-block p-1 text-center mr-5 #{@active && "border-b-2 border-piccolo-120"}"}
-      :if={@to}
-    >
-      <#slot />
-    </Link>
-
+    {#if @patch}
+      <LivePatch
+        to={@to}
+        class={"inline-block p-1 text-center mr-5 #{@active && "border-b-2 border-piccolo-120"}"}
+        :if={@to}
+      >
+        <#slot />
+      </LivePatch>
+    {#else}
+      <Link
+        to={@to}
+        class={"inline-block p-1 text-center mr-5 #{@active && "border-b-2 border-piccolo-120"}"}
+        :if={@to}
+      >
+        <#slot />
+      </Link>
+    {/if}
     <div
       :on-click={@on_click}
       phx-value-item_id={@item_id}

--- a/lib/moon_web/pages/components/tabs_page.ex
+++ b/lib/moon_web/pages/components/tabs_page.ex
@@ -35,8 +35,8 @@ defmodule MoonWeb.Pages.Components.TabsPage do
      )}
   end
 
-  def handle_params(_params, uri, socket) do
-    {:noreply, assign(socket, uri: uri)}
+  def handle_params(params, uri, socket) do
+    {:noreply, assign(socket, uri: uri, tab_id: params["tab_id"] || "1")}
   end
 
   def render(assigns) do
@@ -69,7 +69,11 @@ defmodule MoonWeb.Pages.Components.TabsPage do
                 active={@tab_id == "2"}
                 to={live_path(@socket, __MODULE__, tab_id: "2", theme_name: @theme_name)}
               >Link 2</TabLink>
-              <TabLink active={@tab_id == "3"} on_click="clicked_tab" item_id="3">Link 3</TabLink>
+              <TabLink
+                active={@tab_id == "3"}
+                patch
+                to={live_path(@socket, __MODULE__, tab_id: "3", theme_name: @theme_name)}
+              >Link 3 with url patch, no page reload</TabLink>
               <TabLink active={@tab_id == "4"} on_click="clicked_tab" item_id="4">Link 4</TabLink>
             </Tabs>
           </:example>


### PR DESCRIPTION
tabs now have patch property that enables tab to just patch the url.

#227

Tested with example_page for tabs.
http://localhost:5002/components/tabs?tab_id=1&theme_name=sportsbet-dark