### PR TITLE
WIP ft: example how API for input group should from from external usage

### DIFF
--- a/lib/moon/components/input_group.ex
+++ b/lib/moon/components/input_group.ex
@@ -1,0 +1,21 @@
+defmodule Moon.Components.InputGroup do
+  @moduledoc false
+
+  use Moon.StatelessComponent
+  alias Moon.Components.ErrorTag
+
+  prop orientation, :string, default: "vertical", values: ["vertical", "horizontal"]
+  prop error_from_field, :atom
+  slot(default)
+
+  def render(assigns) do
+    ~F"""
+    <Context put={__MODULE__, is_in_input_group: true, orientation: @orientation}>
+      <div class={flex: @orientation == "horizontal"}>
+        <#slot />
+      </div>
+      <ErrorTag field={@error_from_field} />
+    </Context>
+    """
+  end
+end

--- a/lib/moon/components/text_input/subcomponents/text_input_basic.ex
+++ b/lib/moon/components/text_input/subcomponents/text_input_basic.ex
@@ -23,6 +23,7 @@ defmodule Moon.Components.TextInput.TextInputBasic do
     default: "text"
 
   prop id, :string
+  prop field, :atom
   prop size, :string, values: ["md", "lg", "xl"]
   prop placeholder, :string
   prop is_error, :boolean

--- a/lib/moon/components/text_input/subcomponents/text_input_inner_label.ex
+++ b/lib/moon/components/text_input/subcomponents/text_input_inner_label.ex
@@ -24,6 +24,8 @@ defmodule Moon.Components.TextInput.TextInputInnerLabel do
     default: "text"
 
   prop id, :string
+  prop class, :css_class
+  prop field, :atom
   prop size, :string, values: ["md", "lg", "xl"]
   prop placeholder, :string
   prop is_error, :boolean
@@ -43,7 +45,6 @@ defmodule Moon.Components.TextInput.TextInputInnerLabel do
   prop is_sharp_bottom_side, :boolean
   prop is_top_bottom_border_hidden, :boolean
   prop is_side_border_hidden, :boolean
-
   prop focus, :event
   prop keydown, :event
   prop keyup, :event
@@ -63,6 +64,8 @@ defmodule Moon.Components.TextInput.TextInputInnerLabel do
         "bg-#{@background_color}": @background_color
       }>
         <Input
+          class={@class}
+          field={@field}
           is_error={@is_error}
           size={@size}
           type={@type}

--- a/lib/moon/components/text_input/subcomponents/text_input_password.ex
+++ b/lib/moon/components/text_input/subcomponents/text_input_password.ex
@@ -9,6 +9,8 @@ defmodule Moon.Components.TextInput.TextInputPassword do
   alias Moon.Components.TextInput.ShowPassword
   alias Moon.Components.ErrorTag
 
+  prop field, :atom
+  prop class, :css_class
   prop size, :string, values: ["md", "lg", "xl"]
   prop placeholder, :string
   prop is_error, :boolean
@@ -22,12 +24,6 @@ defmodule Moon.Components.TextInput.TextInputPassword do
   prop readonly, :boolean
   prop value, :string
 
-  prop is_sharp_left_side, :boolean
-  prop is_sharp_right_side, :boolean
-  prop is_sharp_top_side, :boolean
-  prop is_sharp_bottom_side, :boolean
-  prop is_top_bottom_border_hidden, :boolean
-  prop is_side_border_hidden, :boolean
   prop show_password_text, :string, default: "Show"
 
   prop focus, :event

--- a/lib/moon/components/text_input/text_input.ex
+++ b/lib/moon/components/text_input/text_input.ex
@@ -59,8 +59,8 @@ defmodule Moon.Components.TextInput do
     ~F"""
     <InputContext assigns={assigns} :let={form: form, field: field}>
       <Context get={Moon.Components.InputGroup, in_input_group: in_input_group, orientation: orientation}>
-        in_input_group: {in_input_group}<br />
-        orientation: {orientation}<br />
+        in_input_group: {in_input_group}<br>
+        orientation: {orientation}<br>
         {#if @type == "password"}
           <TextInputPassword
             id={@id}
@@ -82,7 +82,7 @@ defmodule Moon.Components.TextInput do
             is_sharp_bottom_side={@is_sharp_bottom_side}
             is_top_bottom_border_hidden={@is_top_bottom_border_hidden}
             is_side_border_hidden={@is_side_border_hidden}
-            class={"border-none"}
+            class="border-none"
             use_error_tag={@use_error_tag}
           >
             <:hint_text_slot>

--- a/lib/moon/components/text_input/text_input.ex
+++ b/lib/moon/components/text_input/text_input.ex
@@ -8,6 +8,7 @@ defmodule Moon.Components.TextInput do
   alias Surface.Components.Form.Input.InputContext
 
   prop id, :string
+  prop field, :atom
   prop size, :string, values: ["md", "lg", "xl"]
 
   prop type, :string,
@@ -57,88 +58,97 @@ defmodule Moon.Components.TextInput do
   def render(assigns) do
     ~F"""
     <InputContext assigns={assigns} :let={form: form, field: field}>
-      {#if @type == "password"}
-        <TextInputPassword
-          id={@id}
-          disabled={@disabled}
-          dir={@dir}
-          label={@label}
-          is_error={has_error(@is_error, form, field)}
-          size={@size}
-          step={@step}
-          required={@required}
-          placeholder={@placeholder}
-          readonly={@readonly}
-          value={@value}
-          background_color={@background_color}
-          is_sharp_left_side={@is_sharp_left_side}
-          is_sharp_right_side={@is_sharp_right_side}
-          is_sharp_top_side={@is_sharp_top_side}
-          is_sharp_bottom_side={@is_sharp_bottom_side}
-          is_top_bottom_border_hidden={@is_top_bottom_border_hidden}
-          is_side_border_hidden={@is_side_border_hidden}
-          is_first={@is_first}
-          use_error_tag={@use_error_tag}
-        >
-          <:hint_text_slot>
-            <#slot name="hint_text_slot" />
-          </:hint_text_slot>
-        </TextInputPassword>
-      {#elseif @size == "xl"}
-        <TextInputInnerLabel
-          disabled={@disabled}
-          dir={@dir}
-          label={@label}
-          is_error={has_error(@is_error, form, field)}
-          size={@size}
-          type={@type}
-          step={@step}
-          required={@required}
-          placeholder={@placeholder}
-          readonly={@readonly}
-          value={@value}
-          background_color={@background_color}
-          is_sharp_left_side={@is_sharp_left_side}
-          is_sharp_right_side={@is_sharp_right_side}
-          is_sharp_top_side={@is_sharp_top_side}
-          is_sharp_bottom_side={@is_sharp_bottom_side}
-          is_top_bottom_border_hidden={@is_top_bottom_border_hidden}
-          is_side_border_hidden={@is_side_border_hidden}
-          is_first={@is_first}
-          use_error_tag={@use_error_tag}
-        >
-          <:hint_text_slot>
-            <#slot name="hint_text_slot" />
-          </:hint_text_slot>
-        </TextInputInnerLabel>
-      {#else}
-        <TextInputBasic
-          disabled={@disabled}
-          dir={@dir}
-          label={@label}
-          is_error={has_error(@is_error, form, field)}
-          size={@size}
-          type={@type}
-          step={@step}
-          readonly={@readonly}
-          value={@value}
-          required={@required}
-          placeholder={@placeholder}
-          background_color={@background_color}
-          is_sharp_left_side={@is_sharp_left_side}
-          is_sharp_right_side={@is_sharp_right_side}
-          is_sharp_top_side={@is_sharp_top_side}
-          is_sharp_bottom_side={@is_sharp_bottom_side}
-          is_top_bottom_border_hidden={@is_top_bottom_border_hidden}
-          is_side_border_hidden={@is_side_border_hidden}
-          is_first={@is_first}
-          use_error_tag={@use_error_tag}
-        >
-          <:hint_text_slot>
-            <#slot name="hint_text_slot" />
-          </:hint_text_slot>
-        </TextInputBasic>
-      {/if}
+      <Context get={Moon.Components.InputGroup, in_input_group: in_input_group, orientation: orientation}>
+        in_input_group: {in_input_group}<br />
+        orientation: {orientation}<br />
+        {#if @type == "password"}
+          <TextInputPassword
+            id={@id}
+            field={@field}
+            disabled={@disabled}
+            dir={@dir}
+            label={@label}
+            is_error={has_error(@is_error, form, field)}
+            size={@size}
+            step={@step}
+            required={@required}
+            placeholder={@placeholder}
+            readonly={@readonly}
+            value={@value}
+            background_color={@background_color}
+            is_sharp_left_side={@is_sharp_left_side}
+            is_sharp_right_side={@is_sharp_right_side}
+            is_sharp_top_side={@is_sharp_top_side}
+            is_sharp_bottom_side={@is_sharp_bottom_side}
+            is_top_bottom_border_hidden={@is_top_bottom_border_hidden}
+            is_side_border_hidden={@is_side_border_hidden}
+            class={"border-none"}
+            use_error_tag={@use_error_tag}
+          >
+            <:hint_text_slot>
+              <#slot name="hint_text_slot" />
+            </:hint_text_slot>
+          </TextInputPassword>
+        {#elseif @size == "xl"}
+          <TextInputInnerLabel
+            id={@id}
+            field={@field}
+            disabled={@disabled}
+            dir={@dir}
+            label={@label}
+            is_error={has_error(@is_error, form, field)}
+            size={@size}
+            type={@type}
+            step={@step}
+            required={@required}
+            placeholder={@placeholder}
+            readonly={@readonly}
+            value={@value}
+            background_color={@background_color}
+            is_sharp_left_side={@is_sharp_left_side}
+            is_sharp_right_side={@is_sharp_right_side}
+            is_sharp_top_side={@is_sharp_top_side}
+            is_sharp_bottom_side={@is_sharp_bottom_side}
+            is_top_bottom_border_hidden={@is_top_bottom_border_hidden}
+            is_side_border_hidden={@is_side_border_hidden}
+            is_first={@is_first}
+            use_error_tag={@use_error_tag}
+          >
+            <:hint_text_slot>
+              <#slot name="hint_text_slot" />
+            </:hint_text_slot>
+          </TextInputInnerLabel>
+        {#else}
+          <TextInputBasic
+            id={@id}
+            field={@field}
+            disabled={@disabled}
+            dir={@dir}
+            label={@label}
+            is_error={has_error(@is_error, form, field)}
+            size={@size}
+            type={@type}
+            step={@step}
+            readonly={@readonly}
+            value={@value}
+            required={@required}
+            placeholder={@placeholder}
+            background_color={@background_color}
+            is_sharp_left_side={@is_sharp_left_side}
+            is_sharp_right_side={@is_sharp_right_side}
+            is_sharp_top_side={@is_sharp_top_side}
+            is_sharp_bottom_side={@is_sharp_bottom_side}
+            is_top_bottom_border_hidden={@is_top_bottom_border_hidden}
+            is_side_border_hidden={@is_side_border_hidden}
+            is_first={@is_first}
+            use_error_tag={@use_error_tag}
+          >
+            <:hint_text_slot>
+              <#slot name="hint_text_slot" />
+            </:hint_text_slot>
+          </TextInputBasic>
+        {/if}
+      </Context>
     </InputContext>
     """
   end

--- a/lib/moon_web/pages/components/input_group_page.ex
+++ b/lib/moon_web/pages/components/input_group_page.ex
@@ -1,0 +1,103 @@
+defmodule MoonWeb.Pages.Components.InputGroupPage do
+  @moduledoc false
+
+  use MoonWeb, :live_view
+
+  alias MoonWeb.Components.ComponentPageDescription
+  alias MoonWeb.Components.ExampleAndCode
+  alias MoonWeb.Components.Page
+
+  alias Moon.Components.Form
+  alias Moon.Components.InputGroup
+  alias Moon.Components.Select.SingleSelect
+  alias Moon.Components.TextInput
+
+  alias MoonWeb.Pages.Tutorials.AddDataUsingForm.User
+
+  data breadcrumbs, :any,
+    default: [
+      %{
+        to: "#",
+        name: "Components"
+      },
+      %{
+        to: "/components/input-group",
+        name: "Input group"
+      }
+    ]
+
+  def render(assigns) do
+    ~F"""
+    <Page theme_name={@theme_name} active_page={@active_page} breadcrumbs={@breadcrumbs}>
+      <ExampleAndCode title="Vertical" id="example_1">
+        <:example>
+          <Form for={@user_changeset} change="form_update" submit="form_update">
+            <InputGroup orientation="vertical" error_from_field={:name_or_role_error}>
+              <TextInput size="xl" label="Name" placeholder="e.g. 1234" field={:name} />
+              <SingleSelect
+                size="xlarge"
+                id="user-roles-example-1"
+                options={User.available_roles()}
+                field={:role}
+              />
+            </InputGroup>
+          </Form>
+
+          <Form for={@user_changeset} change="form_update" submit="form_update">
+            <InputGroup orientation="horizontal" error_from_field={:name_or_role_error}>
+              <TextInput size="xl" label="Name" placeholder="e.g. 1234" field={:name} />
+              <SingleSelect
+                size="xlarge"
+                id="user-roles-example-2"
+                options={User.available_roles()}
+                field={:role}
+              />
+            </InputGroup>
+          </Form>
+        </:example>
+        <:code>{example_1_code()}</:code>
+      </ExampleAndCode>
+      <ComponentPageDescription title="Table">
+        <p>
+          Coming soon...
+        </p>
+      </ComponentPageDescription>
+    </Page>
+    """
+  end
+
+  def mount(params, _session, socket) do
+    user = %User{}
+
+    user_changeset =
+      User.changeset(user, %{}) |> Ecto.Changeset.add_error(:name_or_role_error, "example error")
+
+    user_changeset = Map.merge(user_changeset, %{action: :insert})
+
+    {:ok,
+     assign(socket,
+       theme_name: params["theme_name"] || "moon-design-light",
+       active_page: __MODULE__,
+       user: user,
+       user_changeset: user_changeset
+     )}
+  end
+
+  def handle_event("form_update", params, socket) do
+    user_changeset = User.changeset(socket.assigns.user, params["user"])
+
+    {:noreply, assign(socket, user_changeset: user_changeset)}
+  end
+
+  def example_1_code() do
+    """
+    code1
+    """
+  end
+
+  def example_2_code() do
+    """
+    code2
+    """
+  end
+end

--- a/lib/moon_web/router.ex
+++ b/lib/moon_web/router.ex
@@ -54,7 +54,6 @@ defmodule MoonWeb.Router do
       live "/manifest", MoonWeb.Pages.ManifestPage
       live "/assets/logos", MoonWeb.Pages.Assets.LogosPage
       live "/assets/patterns", MoonWeb.Pages.Assets.PatternsPage
-
       live "/components/accordion", MoonWeb.Pages.Components.AccordionPage
       live "/components/avatar", MoonWeb.Pages.Components.AvatarPage
       live "/components/banner", MoonWeb.Pages.Components.BannerPage
@@ -63,69 +62,53 @@ defmodule MoonWeb.Router do
       live "/components/calendar", MoonWeb.Pages.Components.CalendarPage
       live "/components/card", MoonWeb.Pages.Components.CardPage
       live "/components/carousel", MoonWeb.Pages.Components.CarouselPage
-
       live "/components/charts/geo-map", MoonWeb.Pages.Components.Charts.GeoMapPage
       live "/components/charts/pie", MoonWeb.Pages.Components.Charts.PiePage
       live "/components/charts/line-chart", MoonWeb.Pages.Components.Charts.LineChartPage
       live "/components/charts/table", MoonWeb.Pages.Components.Charts.TablePage
       live "/components/charts/vertical-bar", MoonWeb.Pages.Components.Charts.VerticalBarPage
-
       live "/components/checkbox", MoonWeb.Pages.Components.CheckboxPage
       live "/components/chip", MoonWeb.Pages.Components.ChipPage
-
       live "/components/date/datepicker", MoonWeb.Pages.Components.Date.DatepickerPage
       live "/components/date/single-date", MoonWeb.Pages.Components.Date.SingleDatePage
       live "/components/date/range-date", MoonWeb.Pages.Components.Date.RangeDatePage
-
       live "/components/dialog/modal", MoonWeb.Pages.Components.Dialog.ModalPage
       live "/components/dialog/dialog-content", MoonWeb.Pages.Components.Dialog.ContentPage
       live "/components/dialog/dialog-overlay", MoonWeb.Pages.Components.Dialog.OverlayPage
       live "/components/dialog/dialog-header", MoonWeb.Pages.Components.Dialog.HeaderPage
       live "/components/dialog/dialog-footer", MoonWeb.Pages.Components.Dialog.FooterPage
       live "/components/dialog/popover", MoonWeb.Pages.Components.Dialog.PopoverPage
-
-      live "/components/checkbox-multiselect",
-           MoonWeb.Pages.Components.CheckboxMultiselectPage
-
+      live "/components/checkbox-multiselect", MoonWeb.Pages.Components.CheckboxMultiselectPage
       live "/components/dropdown_menu_button", MoonWeb.Pages.Components.DropdownMenuButtonPage
-
       live "/components/drawer", MoonWeb.Pages.Components.DrawerPage
       live "/components/file-input", MoonWeb.Pages.Components.FileInputPage
+      live "/components/input_group", MoonWeb.Pages.Components.InputGroupPage
       live "/components/label", MoonWeb.Pages.Components.LabelPage
       live "/components/link", MoonWeb.Pages.Components.LinkPage
       live "/components/list_items", MoonWeb.Pages.Components.ListItemsPage
       live "/components/loader", MoonWeb.Pages.Components.LoaderPage
       live "/components/pagination", MoonWeb.Pages.Components.PaginationPage
-
       live "/components/progress/circular", MoonWeb.Pages.Components.Progress.CircularPage
       live "/components/progress/linear", MoonWeb.Pages.Components.Progress.LinearPage
-
       live "/components/radio-button", MoonWeb.Pages.Components.RadioButtonPage
       live "/components/search", MoonWeb.Pages.Components.SearchPage
-
-      #
       live "/components/select/dropdown", MoonWeb.Pages.Components.Select.DropdownPage
       live "/components/select", MoonWeb.Pages.Components.Select.SelectPage
       live "/components/select/single-select", MoonWeb.Pages.Components.Select.SingleSelectPage
       live "/components/select/multi-select", MoonWeb.Pages.Components.Select.MultiSelectPage
-
       live "/components/sidebar", MoonWeb.Pages.Components.SidebarPage
       live "/components/switch", MoonWeb.Pages.Components.SwitchPage
       live "/components/switcher", MoonWeb.Pages.Components.SwitcherPage
       live "/components/tabs", MoonWeb.Pages.Components.TabsPage
       live "/components/tabs/:tab_id", MoonWeb.Pages.Components.TabsPage
       live "/components/table", MoonWeb.Pages.Components.TablePage
-
       live "/components/text-input", MoonWeb.Pages.Components.TextInputPage
-
       live "/components/text-input-group", MoonWeb.Pages.Components.TextInputGroupPage
       live "/components/toast", MoonWeb.Pages.Components.ToastPage
       live "/components/tooltip", MoonWeb.Pages.Components.TooltipPage
-
       live "/components/typography/caption", MoonWeb.Pages.Components.Typography.CaptionPage
       live "/components/typography/heading", MoonWeb.Pages.Components.Typography.HeadingPage
       live "/components/typography/text", MoonWeb.Pages.Components.Typography.TextPage
-
       live "/tutorials/add-data-using-form", MoonWeb.Pages.Tutorials.AddDataUsingForm
       live "/tutorials/installation", MoonWeb.Pages.Tutorials.Installation
 
@@ -133,7 +116,6 @@ defmodule MoonWeb.Router do
            MoonWeb.Pages.Tutorials.Introduction
 
       live "/tutorials/theming-and-visuals", MoonWeb.Pages.Theming.ThemingAndVisuals
-
       live "/example-pages/dashboard", MoonWeb.Pages.ExamplePages.DashboardPage
       live "/example-pages/transactions", MoonWeb.Pages.ExamplePages.TransactionsPage
       live "/example-pages/marketing", MoonWeb.Pages.ExamplePages.MarketingPage


### PR DESCRIPTION
This is example, how API for InputGroup usage should/could work. 

<img width="1721" alt="Screen Shot 2022-08-22 at 01 04 50" src="https://user-images.githubusercontent.com/53759446/185812814-f72cc288-c824-43cd-af59-09eada895a43.png">
Now, there are two options, how TextInput and SingleSelect would work properly in this example:

1. Using pseudoclasses (I recommend this way) https://tailwindcss.com/docs/hover-focus-and-other-states#pseudo-classes
2. Using prop (like is_first and is_last on components) (I do not recommend this way) 

I think React implementation is kind of weird, and I think it should not be used as an example, because:
1. TextInputGroup contains Selects etc (this is counter-intuitive)
2. TextInputGroup creates its own DSL (and does not use normal JSX like syntax)