### PR TITLE
chore: added tooltip clicked event and after clicked text

### DIFF
--- a/lib/moon/components/tooltip.ex
+++ b/lib/moon/components/tooltip.ex
@@ -3,6 +3,7 @@ defmodule Moon.Components.Tooltip do
 
   use Moon.StatelessComponent
 
+  prop clicked_text, :string, default: nil
   prop text, :string, required: true
 
   prop placement, :string,
@@ -17,13 +18,16 @@ defmodule Moon.Components.Tooltip do
 
   def render(assigns) do
     ~F"""
-    <div class="relative inline-block" x-data="{ tooltip: false, timeout: null }">
+    <div class="relative inline-block" x-data="{ tooltip: false, timeout: null, clicked: false}">
       {#case @placement}
         {#match "top"}
           <div x-cloak x-show="tooltip" class="absolute left-0 top-0 right-0 flex flex-col items-center">
             <div class="-translate-y-full">
-              <div class="w-48 p-4 text-moon-14 text-center bg-gohan-100 shadow rounded">
+              <div x-show="!clicked" class="w-48 p-4 text-moon-14 text-center bg-gohan-100 shadow rounded">
                 {@text}
+              </div>
+              <div x-show="clicked" class="w-48 p-4 text-moon-14 text-center bg-gohan-100 shadow rounded">
+                {@clicked_text || @text}
               </div>
               <div class="w-full overflow-hidden">
                 <div class="h-3 w-3 mx-auto bg-gohan-100 -rotate-45 -translate-y-1/2 shadow" />
@@ -36,8 +40,11 @@ defmodule Moon.Components.Tooltip do
               <div class="p-1 overflow-hidden">
                 <div class="h-4 w-4 bg-gohan-100 -rotate-45 translate-x-1/2 shadow" />
               </div>
-              <div class="w-48 p-4 text-moon-14 text-center bg-gohan-100 shadow rounded">
+              <div x-show="!clicked" class="w-48 p-4 text-moon-14 text-center bg-gohan-100 shadow rounded">
                 {@text}
+              </div>
+              <div x-show="clicked" class="w-48 p-4 text-moon-14 text-center bg-gohan-100 shadow rounded">
+                {@clicked_text || @text}
               </div>
             </div>
           </div>
@@ -47,8 +54,11 @@ defmodule Moon.Components.Tooltip do
               <div class="w-full overflow-hidden">
                 <div class="h-3 w-3 mx-auto bg-gohan-100 -rotate-45 translate-y-1/2 shadow" />
               </div>
-              <div class="w-48 p-4 text-moon-14 text-center bg-gohan-100 shadow rounded">
+              <div x-show="!clicked" class="w-48 p-4 text-moon-14 text-center bg-gohan-100 shadow rounded">
                 {@text}
+              </div>
+              <div x-show="clicked" class="w-48 p-4 text-moon-14 text-center bg-gohan-100 shadow rounded">
+                {@clicked_text || @text}
               </div>
             </div>
           </div>
@@ -56,8 +66,11 @@ defmodule Moon.Components.Tooltip do
           <div x-cloak x-show="tooltip" class="absolute left-0 bottom-0 right-0">
             <div class="absolute -translate-x-full -translate-y-full">
               <div class="flex items-center top-0 right-0">
-                <div class="w-48 p-4 text-moon-14 text-center bg-gohan-100 shadow rounded">
+                <div x-show="!clicked" class="w-48 p-4 text-moon-14 text-center bg-gohan-100 shadow rounded">
                   {@text}
+                </div>
+                <div x-show="clicked" class="w-48 p-4 text-moon-14 text-center bg-gohan-100 shadow rounded">
+                  {@clicked_text || @text}
                 </div>
                 <div class="py-1 overflow-hidden">
                   <div class="h-3 w-3 bg-gohan-100 -rotate-45 -translate-x-1/2 shadow" />
@@ -75,7 +88,9 @@ defmodule Moon.Components.Tooltip do
           }, 500)"
         x-on:mouseleave="!!timeout && clearTimeout(timeout)
           timeout = null
-          tooltip = false"
+          tooltip = false
+          clicked = false"
+        x-on:click="clicked = true"
       >
         <#slot />
       </div>


### PR DESCRIPTION
This PR adds ToolTip click event and after clicked text show feature.

ONHOVER
![Screenshot 2022-08-25 at 7 37 16 PM](https://user-images.githubusercontent.com/89451429/186687102-d3302d05-0ce6-4e87-bafb-9d46146d152f.png)

AFTER CLICK
![Screenshot 2022-08-25 at 7 37 08 PM](https://user-images.githubusercontent.com/89451429/186687123-f82e1fc8-fe65-434c-ab60-f2377b437a01.png)
