### PR TITLE
setted correct z-index value

### DIFF
--- a/lib/moon/components/file_input.ex
+++ b/lib/moon/components/file_input.ex
@@ -50,13 +50,13 @@ defmodule Moon.Components.FileInput do
   def render(assigns) do
     ~F"""
     <div class="relative">
-      {live_file_input(@conf, class: "opacity-0 absolute top-0 right-0 h-full w-full z-40")}
+      {live_file_input(@conf, class: "opacity-0 absolute top-0 right-0 h-full w-full z-30")}
       <span :if={@label} class="block mb-2">{@label}</span>
       {#if slot_assigned?(:default)}
         <#slot name="default" />
       {/if}
       {#if !slot_assigned?(:default)}
-        <Button class="z-30" full_width>
+        <Button class="z-20" full_width>
           {@placeholder}
           <:right_icon_slot><IconUpload /></:right_icon_slot>
         </Button>


### PR DESCRIPTION
I reduced the z-index for the file_input so that there are no intersections with the dropdown popover.
Now the z-index value for the button is equal to the z-index value of the modal window, and the input block itself is "above"

References
https://coingaming.atlassian.net/browse/PI-586