### PR TITLE
chore: updated dropdown select icon and content padding

### DIFF
--- a/lib/moon/components/list_items/single_line_item.ex
+++ b/lib/moon/components/list_items/single_line_item.ex
@@ -17,11 +17,11 @@ defmodule Moon.Components.ListItems.SingleLineItem do
   def render(assigns) do
     ~F"""
     <div class={
-      "relative rounded-moon-s-sm text-moon-14 text-bulma-100 leading-6 cursor-pointer flex gap-4 p-4",
+      "relative rounded-moon-s-sm text-moon-14 text-bulma-100 leading-6 cursor-pointer flex",
       @background_color,
       "hover:#{@active_background_color}",
-      "py-2": @size == "medium",
-      "py-3": @size == "large",
+      "gap-2 p-2 py-2": @size == "medium",
+      "gap-4 p-4 py-3": @size == "large",
       "#{@active_background_color}": @current
     }>
       <div class={"flex items-center", grow: @left_grow} :if={slot_assigned?(:left_icon)}>

--- a/lib/moon/components/select/single_select.ex
+++ b/lib/moon/components/select/single_select.ex
@@ -24,7 +24,7 @@ defmodule Moon.Components.Select.SelectedValue.Container do
       >
         {#if @is_icon}
           <Icon
-            class="grid place-content-center pr-2"
+            class="grid place-content-center pr-1"
             icon={@option[:left_icon]}
             style="grid-row: span 3 / span 3;"
           />


### PR DESCRIPTION
This PR fixes the dropdown icon and content padding issues based on size.
ISSUE
<img width="450" alt="image-20220921-060919" src="https://user-images.githubusercontent.com/89451429/191957647-684b2037-10eb-42cc-aaed-8160e8976c56.png">

FIX
<img width="155" alt="Screenshot 2022-09-23 at 5 42 06 PM" src="https://user-images.githubusercontent.com/89451429/191957508-a75da981-1ff6-4f78-bb12-de116d146dc6.png">
