### PR TITLE
Provide fix for ToastStack not using Message.id

### DIFF
--- a/lib/moon/components/toast_stack.ex
+++ b/lib/moon/components/toast_stack.ex
@@ -28,11 +28,12 @@ defmodule Moon.Components.ToastStack do
   end
 
   def show(toast = %Message{}, id) do
-    toast = if toast.id do
-      toast
-    else
-      %{toast | id: generate_id()}
-    end
+    toast =
+      if toast.id do
+        toast
+      else
+        %{toast | id: generate_id()}
+      end
 
     send_update(__MODULE__, id: id, toast: toast)
   end

--- a/lib/moon/components/toast_stack.ex
+++ b/lib/moon/components/toast_stack.ex
@@ -28,13 +28,17 @@ defmodule Moon.Components.ToastStack do
   end
 
   def show(toast = %Message{}, id) do
-    send_update(__MODULE__, id: id, toast: %{toast | id: generate_id()})
+    toast = if toast.id do
+      toast
+    else
+      %{toast | id: generate_id()}
+    end
+
+    send_update(__MODULE__, id: id, toast: toast)
   end
 
   def show(toasts, id) when is_list(toasts) do
-    Enum.each(toasts, fn toast ->
-      send_update(__MODULE__, id: id, toast: %{toast | id: generate_id()})
-    end)
+    Enum.each(toasts, fn toast -> show(toast, id) end)
   end
 
   def hide_toast(toast_id, stack_id) do


### PR DESCRIPTION
[ToastStack](https://github.com/coingaming/moon/blob/main/lib/moon/components/toast_stack.ex) is currently ignoring [`:id` field of Message struct](https://github.com/coingaming/moon/blob/main/lib/moon/components/toast.ex#L25).
It generates random ids and assigns them to new toasts, while it should be allowing user to pass custom id and replace it with [`generate_id/0`](https://github.com/coingaming/moon/blob/main/lib/moon/components/toast_stack.ex#L64) if empty. 

