### PR TITLE
Additional alignment of menu items on sidebar with React TW

### DIFF
--- a/lib/moon_web/components/left_menu.ex
+++ b/lib/moon_web/components/left_menu.ex
@@ -23,7 +23,7 @@ defmodule MoonWeb.Components.LeftMenu do
       :on-click={@click}
       id="left-menu-container"
       class={
-        "hidden fixed h-screen lg:flex lg:flex-shrink-0 w-80 flex-col z-[10000]",
+        "fixed h-screen lg:flex lg:flex-shrink-0 w-80 flex-col z-[10000]",
         @theme_name
       }
     >
@@ -56,8 +56,6 @@ defmodule MoonWeb.Components.LeftMenu do
                 <SidebarLink :if={!@hide_items} route={Pages.ContributePage}>How to contribute</SidebarLink>
                 <SidebarLink route={Pages.ColoursPalettePage}>Colours Palette</SidebarLink>
                 <SidebarLink route={Pages.TokensPage}>Tokens</SidebarLink>
-                <SidebarLink route={Pages.IconsPage}>Icons</SidebarLink>
-                <SidebarLink route={Pages.CountryFlagsPage}>CountryFlags</SidebarLink>
                 <SidebarLink route={Pages.ManifestPage}>Manifest</SidebarLink>
                 <Accordion
                   is_content_inside={false}
@@ -92,6 +90,7 @@ defmodule MoonWeb.Components.LeftMenu do
                       </Accordion>
                       <SidebarLink route={Pages.Components.CheckboxPage}>Checkbox</SidebarLink>
                       <SidebarLink route={Pages.Components.ChipPage}>Chip</SidebarLink>
+                      <SidebarLink route={Pages.Components.CountryFlagsPage}>CountryFlags</SidebarLink>
                       <Accordion
                         :if={!@hide_items}
                         is_content_inside={false}
@@ -127,6 +126,7 @@ defmodule MoonWeb.Components.LeftMenu do
                       </Accordion>
                       <SidebarLink :if={!@hide_items} route={Pages.Components.DrawerPage}>Drawer *</SidebarLink>
                       <SidebarLink :if={!@hide_items} route={Pages.Components.FileInputPage}>File Input *</SidebarLink>
+                      <SidebarLink route={Pages.Components.IconsPage}>Icons</SidebarLink>
                       <SidebarLink route={Pages.Components.LabelPage}>Label</SidebarLink>
                       <SidebarLink :if={!@hide_items} route={Pages.Components.ListItemsPage}>List items</SidebarLink>
                       <SidebarLink route={Pages.Components.LoaderPage}>Loader</SidebarLink>
@@ -164,10 +164,9 @@ defmodule MoonWeb.Components.LeftMenu do
                       </Accordion>
                       <SidebarLink route={Pages.Components.SwitchPage}>Switch</SidebarLink>
                       <SidebarLink :if={!@hide_items} route={Pages.Components.TabsPage}>Tabs</SidebarLink>
-                      <SidebarLink :if={!@hide_items} route={Pages.Components.TablePage}>Table</SidebarLink>
-                      <SidebarLink route={Pages.Components.TextInputPage}>Text input</SidebarLink>
-                      <SidebarLink route={Pages.Components.InputGroupPage}>Input group</SidebarLink>
                       <SidebarLink route={Pages.Components.TablePage}>Table</SidebarLink>
+                      <SidebarLink route={Pages.Components.TextInputPage}>TextInput</SidebarLink>
+                      <SidebarLink route={Pages.Components.InputGroupPage}>TextInputGroup</SidebarLink>
                       <SidebarLink :if={!@hide_items} route={Pages.Components.ToastPage}>Toast</SidebarLink>
                       <SidebarLink :if={!@hide_items} route={Pages.Components.TooltipPage}>Tooltip</SidebarLink>
                       <SidebarLink route={Pages.Components.TypographyPage}>Typography</SidebarLink>

--- a/lib/moon_web/pages/components/country_flags_page.ex
+++ b/lib/moon_web/pages/components/country_flags_page.ex
@@ -1,4 +1,4 @@
-defmodule MoonWeb.Pages.CountryFlagsPage do
+defmodule MoonWeb.Pages.Components.CountryFlagsPage do
   @moduledoc false
 
   use MoonWeb, :live_view
@@ -12,7 +12,11 @@ defmodule MoonWeb.Pages.CountryFlagsPage do
   data(breadcrumbs, :any,
     default: [
       %{
-        to: "/country_flags",
+        to: "#",
+        name: "Components"
+      },
+      %{
+        to: "/components/country_flags",
         name: "CountryFlags"
       }
     ]

--- a/lib/moon_web/pages/components/icons_page_full_list.ex
+++ b/lib/moon_web/pages/components/icons_page_full_list.ex
@@ -1,4 +1,4 @@
-defmodule MoonWeb.Pages.IconsPageFullList do
+defmodule MoonWeb.Pages.Components.IconsPageFullList do
   @moduledoc false
 
   use MoonWeb, :live_view

--- a/lib/moon_web/pages/main_page.ex
+++ b/lib/moon_web/pages/main_page.ex
@@ -16,7 +16,7 @@ defmodule MoonWeb.Pages.MainPage do
     ~F"""
     <Page {=@theme_name} {=@active_page} {=@direction}>
       <div class="relative z-5 flex flex-col gap-12">
-        <div class="self-start"><Label size="twoxsmall" color="text-gohan">Open Source</Label></div>
+        <div class="self-start"><Label size="twoxsmall" color="text-gohan" class="font-medium">Open Source</Label></div>
         <div class="flex flex-col gap-16">
           <div class="relative z-50 flex flex-col items-start gap-6">
             <h1 class="text-moon-64 font-semibold">Moon design system.</h1>

--- a/lib/moon_web/pages/tutorials/icons/icons_page.ex
+++ b/lib/moon_web/pages/tutorials/icons/icons_page.ex
@@ -1,4 +1,4 @@
-defmodule MoonWeb.Pages.IconsPage do
+defmodule MoonWeb.Pages.Components.IconsPage do
   @moduledoc false
 
   use MoonWeb, :live_view
@@ -18,7 +18,11 @@ defmodule MoonWeb.Pages.IconsPage do
   data(breadcrumbs, :any,
     default: [
       %{
-        to: "/icons",
+        to: "#",
+        name: "Components"
+      },
+      %{
+        to: "/components/icons",
         name: "Icons"
       }
     ]

--- a/lib/moon_web/router.ex
+++ b/lib/moon_web/router.ex
@@ -51,8 +51,6 @@ defmodule MoonWeb.Router do
         live("/assets/currencies", MoonWeb.Pages.Assets.CurrenciesPage)
         live("/assets/duotones", MoonWeb.Pages.Assets.DuotonesPage)
         live("/assets/icons", MoonWeb.Pages.Assets.IconsPage)
-        live("/icons", MoonWeb.Pages.IconsPage)
-        live("/country-flags", MoonWeb.Pages.CountryFlagsPage)
         live("/manifest", MoonWeb.Pages.ManifestPage)
         live("/assets/logos", MoonWeb.Pages.Assets.LogosPage)
         live("/assets/patterns", MoonWeb.Pages.Assets.PatternsPage)
@@ -74,6 +72,7 @@ defmodule MoonWeb.Router do
 
         live("/components/checkbox", MoonWeb.Pages.Components.CheckboxPage)
         live("/components/chip", MoonWeb.Pages.Components.ChipPage)
+        live("/components/country-flags", MoonWeb.Pages.Components.CountryFlagsPage)
 
         live("/components/date/datepicker", MoonWeb.Pages.Components.Date.DatepickerPage)
         live("/components/date/single-date", MoonWeb.Pages.Components.Date.SingleDatePage)
@@ -95,6 +94,7 @@ defmodule MoonWeb.Router do
 
         live("/components/drawer", MoonWeb.Pages.Components.DrawerPage)
         live("/components/file-input", MoonWeb.Pages.Components.FileInputPage)
+        live("/components/icons", MoonWeb.Pages.Components.IconsPage)
         live("/components/label", MoonWeb.Pages.Components.LabelPage)
         live("/components/link", MoonWeb.Pages.Components.LinkPage)
         live("/components/list_items", MoonWeb.Pages.Components.ListItemsPage)


### PR DESCRIPTION
1. Moved Icons and CountryFlags into Components section
2. Adjusted (alphabetical) order of menu items
3. Aligned spelling of menu items with React TW
4. Removed “hidden” class definition from left-menu.ex, so that menu wouldn’t close immediately after menu item is selected
5. Changed font weight of “Open Source” label to medium