### PR TITLE
fix: Additional alignment of menu items on sidebar with React TW

### DIFF
--- a/lib/moon/components/link.ex
+++ b/lib/moon/components/link.ex
@@ -25,7 +25,7 @@ defmodule Moon.Components.Link do
           !@disabled and !@optional and !@secondary,
         "cursor-pointer": !@disabled,
         "cursor-not-allowed opacity-25": @disabled,
-        "text-piccolo": !@secondary && !@optional,
+        "text-bulma hover:underline focus:underline active:underline": !@secondary && !@optional,
         "text-trunks": @secondary,
         "text-trunks hover:text-piccolo-80 focus:text-bulma active:text-bulma": @optional
       }

--- a/lib/moon_web/components/header.ex
+++ b/lib/moon_web/components/header.ex
@@ -15,7 +15,7 @@ defmodule MoonWeb.Components.Header do
       <div class="relative z-10 py-4 lg:hidden flex flex-row gap-2 items-center justify-between text-bulma">
         <button type="button" class="focus:outline-none" :on-click={@click}>
           <span class="sr-only">Open sidebar</span>
-          <GenericMenu class="text-moon-32"/>
+          <GenericMenu class="text-moon-32" />
         </button>
         <a href="/">
           <LogoMoonDesignShort height="2em" width="2em" />

--- a/lib/moon_web/components/header.ex
+++ b/lib/moon_web/components/header.ex
@@ -4,17 +4,18 @@ defmodule MoonWeb.Components.Header do
   use MoonWeb, :stateless_component
 
   alias Moon.Assets.Logos.LogoMoonDesignShort
+  alias Moon.Icons.GenericMenu
 
   prop(click, :event)
   slot(default)
 
   def render(assigns) do
     ~F"""
-    <header>
+    <header class="fixed top-0 bg-gohan z-50 px-5 w-full">
       <div class="relative z-10 py-4 lg:hidden flex flex-row gap-2 items-center justify-between text-bulma">
         <button type="button" class="focus:outline-none" :on-click={@click}>
           <span class="sr-only">Open sidebar</span>
-          <img src={static_path(MoonWeb.Endpoint, "/svgs/moon_web/left_menu.svg")}>
+          <GenericMenu class="text-moon-32"/>
         </button>
         <a href="/">
           <LogoMoonDesignShort height="2em" width="2em" />

--- a/lib/moon_web/components/left_menu.ex
+++ b/lib/moon_web/components/left_menu.ex
@@ -56,8 +56,6 @@ defmodule MoonWeb.Components.LeftMenu do
                 <SidebarLink :if={!@hide_items} route={Pages.ContributePage}>How to contribute</SidebarLink>
                 <SidebarLink route={Pages.ColoursPalettePage}>Colours Palette</SidebarLink>
                 <SidebarLink route={Pages.TokensPage}>Tokens</SidebarLink>
-                <SidebarLink route={Pages.IconsPage}>Icons</SidebarLink>
-                <SidebarLink route={Pages.CountryFlagsPage}>CountryFlags</SidebarLink>
                 <SidebarLink route={Pages.ManifestPage}>Manifest</SidebarLink>
                 <Accordion
                   is_content_inside={false}
@@ -92,6 +90,7 @@ defmodule MoonWeb.Components.LeftMenu do
                       </Accordion>
                       <SidebarLink route={Pages.Components.CheckboxPage}>Checkbox</SidebarLink>
                       <SidebarLink route={Pages.Components.ChipPage}>Chip</SidebarLink>
+                      <SidebarLink route={Pages.Components.CountryFlagsPage}>CountryFlags</SidebarLink>
                       <Accordion
                         :if={!@hide_items}
                         is_content_inside={false}
@@ -127,6 +126,7 @@ defmodule MoonWeb.Components.LeftMenu do
                       </Accordion>
                       <SidebarLink :if={!@hide_items} route={Pages.Components.DrawerPage}>Drawer *</SidebarLink>
                       <SidebarLink :if={!@hide_items} route={Pages.Components.FileInputPage}>File Input *</SidebarLink>
+                      <SidebarLink route={Pages.Components.IconsPage}>Icons</SidebarLink>
                       <SidebarLink route={Pages.Components.LabelPage}>Label</SidebarLink>
                       <SidebarLink :if={!@hide_items} route={Pages.Components.ListItemsPage}>List items</SidebarLink>
                       <SidebarLink route={Pages.Components.LoaderPage}>Loader</SidebarLink>
@@ -164,10 +164,9 @@ defmodule MoonWeb.Components.LeftMenu do
                       </Accordion>
                       <SidebarLink route={Pages.Components.SwitchPage}>Switch</SidebarLink>
                       <SidebarLink :if={!@hide_items} route={Pages.Components.TabsPage}>Tabs</SidebarLink>
-                      <SidebarLink :if={!@hide_items} route={Pages.Components.TablePage}>Table</SidebarLink>
-                      <SidebarLink route={Pages.Components.TextInputPage}>Text input</SidebarLink>
-                      <SidebarLink route={Pages.Components.InputGroupPage}>Input group</SidebarLink>
                       <SidebarLink route={Pages.Components.TablePage}>Table</SidebarLink>
+                      <SidebarLink route={Pages.Components.TextInputPage}>TextInput</SidebarLink>
+                      <SidebarLink route={Pages.Components.InputGroupPage}>TextInputGroup</SidebarLink>
                       <SidebarLink :if={!@hide_items} route={Pages.Components.ToastPage}>Toast</SidebarLink>
                       <SidebarLink :if={!@hide_items} route={Pages.Components.TooltipPage}>Tooltip</SidebarLink>
                       <SidebarLink route={Pages.Components.TypographyPage}>Typography</SidebarLink>

--- a/lib/moon_web/components/page.ex
+++ b/lib/moon_web/components/page.ex
@@ -29,13 +29,13 @@ defmodule MoonWeb.Components.Page do
         hide_items
       />
       <Header click={show_left_menu()}>
-      <Breadcrumbs
-        class="pb-12 hidden lg:block"
-        :if={@breadcrumbs}
-        theme_name={@theme_name}
-        breadcrumbs={@breadcrumbs}
-      />
-    </Header>
+        <Breadcrumbs
+          class="pb-12 hidden lg:block"
+          :if={@breadcrumbs}
+          theme_name={@theme_name}
+          breadcrumbs={@breadcrumbs}
+        />
+      </Header>
       <div class={
         "min-h-screen lg:ms-80 bg-gohan flex-1 w-0 flex flex-col lg:rounded-tl-3xl lg:rounded-bl-3xl px-5 xl:px-20 2xl:px-32 lg:pt-12",
         @theme_name

--- a/lib/moon_web/components/page.ex
+++ b/lib/moon_web/components/page.ex
@@ -28,20 +28,19 @@ defmodule MoonWeb.Components.Page do
         click={hide_left_menu()}
         hide_items
       />
-
+      <Header click={show_left_menu()}>
+      <Breadcrumbs
+        class="pb-12 hidden lg:block"
+        :if={@breadcrumbs}
+        theme_name={@theme_name}
+        breadcrumbs={@breadcrumbs}
+      />
+    </Header>
       <div class={
         "min-h-screen lg:ms-80 bg-gohan flex-1 w-0 flex flex-col lg:rounded-tl-3xl lg:rounded-bl-3xl px-5 xl:px-20 2xl:px-32 lg:pt-12",
         @theme_name
       }>
-        <div class="flex flex-col grow max-w-screen-xl">
-          <Header click={show_left_menu()}>
-            <Breadcrumbs
-              class="pb-12 hidden lg:block"
-              :if={@breadcrumbs}
-              theme_name={@theme_name}
-              breadcrumbs={@breadcrumbs}
-            />
-          </Header>
+        <div class="flex flex-col grow max-w-screen-xl pt-16">
           <div class="flex flex-col gap-12 flex-1 relative overflow-y-auto focus:outline-none">
             <#slot />
           </div>

--- a/lib/moon_web/pages/components/country_flags_page.ex
+++ b/lib/moon_web/pages/components/country_flags_page.ex
@@ -1,4 +1,4 @@
-defmodule MoonWeb.Pages.CountryFlagsPage do
+defmodule MoonWeb.Pages.Components.CountryFlagsPage do
   @moduledoc false
 
   use MoonWeb, :live_view
@@ -12,7 +12,11 @@ defmodule MoonWeb.Pages.CountryFlagsPage do
   data(breadcrumbs, :any,
     default: [
       %{
-        to: "/country_flags",
+        to: "#",
+        name: "Components"
+      },
+      %{
+        to: "/components/country_flags",
         name: "CountryFlags"
       }
     ]

--- a/lib/moon_web/pages/main_page.ex
+++ b/lib/moon_web/pages/main_page.ex
@@ -16,9 +16,9 @@ defmodule MoonWeb.Pages.MainPage do
     ~F"""
     <Page {=@theme_name} {=@active_page} {=@direction}>
       <div class="relative z-5 flex flex-col gap-12">
-        <div class="self-start"><Label size="twoxsmall" color="text-gohan">Open Source</Label></div>
+        <div class="self-start"><Label size="twoxsmall" color="text-gohan" class="font-medium">Open Source</Label></div>
         <div class="flex flex-col gap-16">
-          <div class="relative z-50 flex flex-col items-start gap-6">
+          <div class="relative z-40 flex flex-col items-start gap-6">
             <h1 class="text-moon-64 font-semibold">Moon design system.</h1>
             <p class="text-moon-24 max-w-screen-sm">
               Moon is Yolo Group product design system that helps us maintain the
@@ -33,7 +33,7 @@ defmodule MoonWeb.Pages.MainPage do
               </a>
             </p>
           </div>
-          <div class="flex flex-col lg:flex-row gap-4 3xl:fixed 3xl:top-12 ltr:3xl:right-12 rtl:3xl:left-12 z-50">
+          <div class="flex flex-col lg:flex-row gap-4 3xl:fixed 3xl:top-12 ltr:3xl:right-12 rtl:3xl:left-12 z-40">
             <ForDevelopers {=@theme_name} {=@direction} />
             <ForDesigners {=@theme_name} {=@direction} />
           </div>

--- a/lib/moon_web/pages/tutorials/icons/icons_page.ex
+++ b/lib/moon_web/pages/tutorials/icons/icons_page.ex
@@ -1,4 +1,4 @@
-defmodule MoonWeb.Pages.IconsPage do
+defmodule MoonWeb.Pages.Components.IconsPage do
   @moduledoc false
 
   use MoonWeb, :live_view
@@ -18,7 +18,11 @@ defmodule MoonWeb.Pages.IconsPage do
   data(breadcrumbs, :any,
     default: [
       %{
-        to: "/icons",
+        to: "#",
+        name: "Components"
+      },
+      %{
+        to: "/components/icons",
         name: "Icons"
       }
     ]

--- a/lib/moon_web/router.ex
+++ b/lib/moon_web/router.ex
@@ -51,8 +51,6 @@ defmodule MoonWeb.Router do
         live("/assets/currencies", MoonWeb.Pages.Assets.CurrenciesPage)
         live("/assets/duotones", MoonWeb.Pages.Assets.DuotonesPage)
         live("/assets/icons", MoonWeb.Pages.Assets.IconsPage)
-        live("/icons", MoonWeb.Pages.IconsPage)
-        live("/country-flags", MoonWeb.Pages.CountryFlagsPage)
         live("/manifest", MoonWeb.Pages.ManifestPage)
         live("/assets/logos", MoonWeb.Pages.Assets.LogosPage)
         live("/assets/patterns", MoonWeb.Pages.Assets.PatternsPage)
@@ -74,6 +72,7 @@ defmodule MoonWeb.Router do
 
         live("/components/checkbox", MoonWeb.Pages.Components.CheckboxPage)
         live("/components/chip", MoonWeb.Pages.Components.ChipPage)
+        live("/components/country-flags", MoonWeb.Pages.Components.CountryFlagsPage)
 
         live("/components/date/datepicker", MoonWeb.Pages.Components.Date.DatepickerPage)
         live("/components/date/single-date", MoonWeb.Pages.Components.Date.SingleDatePage)
@@ -95,6 +94,7 @@ defmodule MoonWeb.Router do
 
         live("/components/drawer", MoonWeb.Pages.Components.DrawerPage)
         live("/components/file-input", MoonWeb.Pages.Components.FileInputPage)
+        live("/components/icons", MoonWeb.Pages.Components.IconsPage)
         live("/components/label", MoonWeb.Pages.Components.LabelPage)
         live("/components/link", MoonWeb.Pages.Components.LinkPage)
         live("/components/list_items", MoonWeb.Pages.Components.ListItemsPage)

--- a/priv/static/svgs/moon_web/left_menu.svg
+++ b/priv/static/svgs/moon_web/left_menu.svg
@@ -1,9 +1,0 @@
-<svg
-    width="32"
-    height="32"
-    viewBox="0 0 32 32"
-    fill="none"
-    xmlns="http://www.w3.org/2000/svg"
->
-    <path d="M7.5 11.5h17m-17 8h17" stroke="currentColor" stroke-linecap="round" />
-</svg>

--- a/scripts/typescript/icons-old-importer.ts
+++ b/scripts/typescript/icons-old-importer.ts
@@ -156,7 +156,7 @@ const generateAssetsDocumentationPageContent = (
   modules: string[]
 ): string => {
   return `
-defmodule MoonWeb.Pages.IconsPage do
+defmodule MoonWeb.Pages.Components.IconsPage do
   @moduledoc false
 
   use MoonWeb, :live_view


### PR DESCRIPTION
1. Moved Icons and CountryFlags into Components section
2. Adjusted (alphabetical) order of menu items
3. Aligned spelling of menu items with React TW
4. Changed font weight of “Open Source” label to medium
5. Changed footer link colour to Bulma and added underline to hover, focus and active states
6. Replaced menu icon with GenericMenu component
7. Changed Header component to be fixed - better UX on mobile 