### PR TITLE
feat: Remove testid from AsComponent since it's passed in args

### DIFF
--- a/lib/moon/design/button.ex
+++ b/lib/moon/design/button.ex
@@ -68,12 +68,12 @@ defmodule Moon.Design.Button do
         @class
       ])}
       on_click={@on_click}
+      testid={@testid}
       attrs={
         disabled: @disabled,
         type: @type,
         form: @form,
         "data-size": @size,
-        "data-testid": @testid,
         ":values": @values
       }
     >

--- a/lib/moon/design/button/icon_button.ex
+++ b/lib/moon/design/button/icon_button.ex
@@ -53,12 +53,12 @@ defmodule Moon.Design.Button.IconButton do
         @class
       ])}
       on_click={@on_click}
+      testid={@testid}
       attrs={
         disabled: @disabled,
         type: @type,
         form: @form,
         "data-size": @size,
-        "data-testid": @testid,
         ":values": @values
       }
     >

--- a/lib/moon/design/menu_item.ex
+++ b/lib/moon/design/menu_item.ex
@@ -42,9 +42,7 @@ defmodule Moon.Design.MenuItem do
       }
       on_click={@on_click}
       values={is_selected: !@is_selected}
-      attrs={
-        "data-testid": @testid
-      }
+      testid={@testid}
     >
       <#slot context_put={is_selected: @is_selected}>
         <Lego.Title {=@title} :if={@title && !@text} />


### PR DESCRIPTION
This fixes an issue when a parent component provides arguments as:

```elixir
      attrs={
        "data-testid": @testid
      }
```

and it's being overridden by `data-testid={@testid}` inside the component itself:

