### PR TITLE
fix: min width of dropdowns

### DIFF
--- a/lib/moon/components/select/multi_select.ex
+++ b/lib/moon/components/select/multi_select.ex
@@ -181,7 +181,7 @@ defmodule Moon.Components.Select.MultiSelect do
         <TopToDown>
           <div class={
             "overflow-auto rounded-moon-i-md box-border border border-solid",
-            "border-beerus min-w-full min-h-[20px] max-h-[200px] drop-shadow-2xl",
+            "border-beerus min-h-[20px] max-h-[200px] drop-shadow-2xl",
             "#{@search_min_width}": not is_nil(@on_search_change)
           }>
             <Dropdown

--- a/lib/moon/components/select/single_select.ex
+++ b/lib/moon/components/select/single_select.ex
@@ -91,7 +91,7 @@ defmodule Moon.Components.Select.SingleSelect do
         <TopToDown>
           <div class={
             "overflow-auto rounded-moon-i-md box-border border border-solid",
-            "border-beerus min-w-full min-h-[20px] max-h-[200px] drop-shadow-2xl",
+            "border-beerus min-h-[20px] max-h-[200px] drop-shadow-2xl",
             "#{@search_min_width}": not is_nil(@on_search_change)
           }>
             <Dropdown


### PR DESCRIPTION
## How it looks 

**before fixing**
<img width="191" alt="image" src="https://github.com/coingaming/moon/assets/101857946/f3fe8f8e-b283-4033-bc1c-d8f0f0fac336">

**after fixing**
<img width="186" alt="image" src="https://github.com/coingaming/moon/assets/101857946/58c9cebc-f427-4ce3-ac71-7794cb17a51d">
