### PR TITLE
fix: MDS-903 search w/o results

### DIFF
--- a/lib/moon/design/search.ex
+++ b/lib/moon/design/search.ex
@@ -82,8 +82,8 @@ defmodule Moon.Design.Search do
               </Dropdown.Link>
             </#slot>
             {!-- Use @options == [] to avoid any crash due type input using Enum.empty? --}
-            <#slot {@no_result}>
-              <Search.NoResult label={@no_results_label} search={@filter} {=@size} :if={@options == []} />
+            <#slot {@no_result, search: @filter, label: @no_results_label, size: @size} :if={@options == []}>
+              <Search.NoResult label={@no_results_label} search={@filter} {=@size} />
             </#slot>
           </Dropdown.Options>
         </#slot>

--- a/lib/moon/design/search.ex
+++ b/lib/moon/design/search.ex
@@ -42,6 +42,8 @@ defmodule Moon.Design.Search do
   slot(trigger)
   @doc "Slot used for rendering single option. option[:key] will be used if not given"
   slot(option)
+  @doc "When no results are found - this slot will be rendered"
+  slot(no_result)
 
   def render(assigns) do
     ~F"""
@@ -80,7 +82,9 @@ defmodule Moon.Design.Search do
               </Dropdown.Link>
             </#slot>
             {!-- Use @options == [] to avoid any crash due type input using Enum.empty? --}
-            <Search.NoResult label={@no_results_label} search={@filter} {=@size} :if={@options == []} />
+            <#slot {@no_result}>
+              <Search.NoResult label={@no_results_label} search={@filter} {=@size} :if={@options == []} />
+            </#slot>
           </Dropdown.Options>
         </#slot>
       </Dropdown>

--- a/lib/moon/design/search.ex
+++ b/lib/moon/design/search.ex
@@ -79,6 +79,7 @@ defmodule Moon.Design.Search do
                 {option[:key]}
               </Dropdown.Link>
             </#slot>
+            {!-- Use @options == [] to avoid any crash due type input using Enum.empty? --}
             <Search.NoResult label={@no_results_label} search={@filter} {=@size} :if={@options == []} />
           </Dropdown.Options>
         </#slot>

--- a/lib/moon/design/search.ex
+++ b/lib/moon/design/search.ex
@@ -34,6 +34,8 @@ defmodule Moon.Design.Search do
   prop(on_change, :event)
   @doc "Additional attributes for the option link"
   prop(attrs, :map, default: %{})
+  @doc "Label to use in the beginning in case of no results"
+  prop(no_results_label, :string, default: "Search for")
   @doc "Option for custom stylings - use it to show icons or anything else"
   slot(default)
   @doc "Trigger element for the dropdown, default is Dropdown.Select"
@@ -77,6 +79,7 @@ defmodule Moon.Design.Search do
                 {option[:key]}
               </Dropdown.Link>
             </#slot>
+            <Search.NoResult label={@no_results_label} search={@filter} {=@size} :if={@options == []} />
           </Dropdown.Options>
         </#slot>
       </Dropdown>

--- a/lib/moon/design/search/no_result.ex
+++ b/lib/moon/design/search/no_result.ex
@@ -1,0 +1,30 @@
+defmodule Moon.Design.Search.NoResult do
+  @moduledoc "No Result Label for Search Component"
+
+  use Moon.StatelessComponent
+
+  alias Moon.Design.Dropdown
+
+  @doc "Label to use in the beginning in case of no result"
+  prop(label, :string, required: true)
+  @doc "Id of the component"
+  prop(id, :string)
+  @doc "Input of the search"
+  prop(search, :string)
+  @doc "Additional classes for the <span> tag"
+  prop(class, :css_class, from_context: :class)
+  @doc "Common moon size property"
+  prop(size, :string, values!: ~w(sm md lg), default: "md")
+
+  def render(assigns) do
+    ~F"""
+    <Dropdown.Option {=@size} disabled={false} is_selected={false} class="block">
+      {!-- Use span instead of div, div is not valid child of button https://www.w3.org/TR/2012/WD-html5-20120329/the-button-element.html --}
+      <span class={merge(["max-w-md truncate text-bulma w-full text-center", @class])}>
+        {@label |> String.capitalize()}
+        &nbsp;"<span class="font-medium">{@search}</span>"
+      </span>
+    </Dropdown.Option>
+    """
+  end
+end

--- a/lib/moon/design/search/no_result.ex
+++ b/lib/moon/design/search/no_result.ex
@@ -1,7 +1,7 @@
 defmodule Moon.Design.Search.NoResult do
   @moduledoc "No Result Label for Search Component"
 
-  use Moon.StatelessComponent
+  use Moon.StatelessComponent, slot: "no_result"
 
   alias Moon.Design.Dropdown
 


### PR DESCRIPTION
## Issue

The Elixir version doesn't align with the React version, in case lack of available options cause the dropdown to render empty. As per our design, we should display a label in this scenario.

### Notes:
- `:if={@options == []}` is used instead of `Enum.empty?` to avoid possible crash in case of nil, empty or not enum.
- `<span>` is used instead of `<div>` to follow HTML rules.
- label should be customizable to be translated in case needed.

### TODO:
- Add slot to allow customization or removal of it, DONE ( thank you @phgrey )