### PR TITLE
fix: Sorting icon for table update [MDS-971]

### DIFF
--- a/lib/moon/design/table.ex
+++ b/lib/moon/design/table.ex
@@ -69,7 +69,7 @@ defmodule Moon.Design.Table do
   prop(body_attrs, :map, default: %{})
 
   @doc "Icon for sorting"
-  prop(sorting_icon, :string, default: "controls_chevron_up_small")
+  prop(sorting_icon, :string, default: "arrows_up")
 
   @doc "Icon color for sorting"
   prop(sorting_icon_color, :string)

--- a/lib/moon/design/table.ex
+++ b/lib/moon/design/table.ex
@@ -68,6 +68,9 @@ defmodule Moon.Design.Table do
   @doc "Additional attributes for tbody tag"
   prop(body_attrs, :map, default: %{})
 
+  @doc "Icon for sorting"
+  prop(sorting_icon, :string, default: "controls_chevron_up_small")
+
   def render(assigns) do
     import Moon.Light.Table.Helper
 
@@ -109,7 +112,7 @@ defmodule Moon.Design.Table do
                   "rotate-180": @sort[:"#{col[:name]}"] != "ASC",
                   "opacity-0": !@sort[:"#{col[:name]}"]
                 }
-                name="arrows_up"
+                name={@sorting_icon}
               />
             </th>
           {/for}

--- a/lib/moon/design/table.ex
+++ b/lib/moon/design/table.ex
@@ -69,7 +69,7 @@ defmodule Moon.Design.Table do
   prop(body_attrs, :map, default: %{})
 
   @doc "Icon for sorting"
-  prop(sorting_icon, :string, default: "arrows_up")
+  prop(sorting_icon, :string, default: "controls_chevron_up_small")
 
   @doc "Icon color for sorting"
   prop(sorting_icon_color, :string)

--- a/lib/moon/design/table.ex
+++ b/lib/moon/design/table.ex
@@ -72,7 +72,7 @@ defmodule Moon.Design.Table do
   prop(sorting_icon, :string, default: "controls_chevron_up_small")
 
   @doc "Icon color for sorting"
-  prop(sorting_icon_color, :string, default: "text-bulma")
+  prop(sorting_icon_color, :string)
 
   def render(assigns) do
     import Moon.Light.Table.Helper

--- a/lib/moon/design/table.ex
+++ b/lib/moon/design/table.ex
@@ -71,6 +71,9 @@ defmodule Moon.Design.Table do
   @doc "Icon for sorting"
   prop(sorting_icon, :string, default: "controls_chevron_up_small")
 
+  @doc "Icon color for sorting"
+  prop(sorting_icon_color, :string, default: "text-bulma")
+
   def render(assigns) do
     import Moon.Light.Table.Helper
 
@@ -108,6 +111,7 @@ defmodule Moon.Design.Table do
               <Icon
                 :if={col[:name] && col[:sortable]}
                 class={
+                  @sorting_icon_color,
                   "text-[1.5em] transition-transform transition-200",
                   "rotate-180": @sort[:"#{col[:name]}"] != "ASC",
                   "opacity-0": !@sort[:"#{col[:name]}"]

--- a/lib/moon/parts/table.ex
+++ b/lib/moon/parts/table.ex
@@ -68,5 +68,11 @@ defmodule Moon.Parts.Table do
   @doc "Additional attributes for tbody tag"
   prop(body_attrs, :map, default: %{})
 
+  @doc "Icon for sorting"
+  prop(sorting_icon, :string, default: "controls_chevron_up_small")
+
+  @doc "Icon color for sorting"
+  prop(sorting_icon_color, :string, default: "text-bulma")
+
   defdelegate render(assigns), to: Moon.Design.Table
 end


### PR DESCRIPTION
### Issue:

Sorting icon is wrong, we need to use by default `chevron-small`, plus I added the possibility to customize it in case needed.

### API Changes:

- Is possible to customize the color using the `text-*` class, `sorting_icon_color` is added to cover it, by default is set to `bulma` for `Moon.Parts` , in the design is unset
- Is possible to customize the icon using the `sorting_icon` prop, by default `controls_chevron_up_small`
note:
You need to specify only the `up` icon, the `down` icon is rendered by rotating the up by 180deg

### Default:

<img width="322" alt="Screenshot 2024-01-23 at 12 06 42" src="https://github.com/coingaming/moon/assets/4175371/5f93d174-123b-47e9-b303-1305209b4ec1">


### Example:

![sorting-icon](https://github.com/coingaming/moon/assets/4175371/bf590c96-3461-43f5-ac06-9406af67049a)

