### PR TITLE
feat: use Popover id prop

### DIFF
--- a/lib/moon/components/datepicker.ex
+++ b/lib/moon/components/datepicker.ex
@@ -53,7 +53,7 @@ defmodule Moon.Components.Datepicker do
   def render(assigns) do
     ~F"""
     <div>
-      <Popover show={@show} on_close="toggle_picker" testid={@testid}>
+      <Popover id={"#{@id}-popover"} show={@show} on_close="toggle_picker" testid={@testid}>
         <Chip
           class={@button_class}
           on_click="toggle_picker"

--- a/lib/moon/components/dropdown_menu_button.ex
+++ b/lib/moon/components/dropdown_menu_button.ex
@@ -4,6 +4,7 @@ defmodule Moon.Components.DropdownMenuButton do
   use Moon.StatelessComponent
   alias Moon.Components.Popover
 
+  prop(id, :string, required: true)
   prop(class, :string)
   prop(title, :string)
   prop(height, :integer, default: 10)
@@ -20,7 +21,7 @@ defmodule Moon.Components.DropdownMenuButton do
 
   def render(assigns) do
     ~F"""
-    <Popover {=@show} on_close={@on_toggle} {=@placement}>
+    <Popover {=@id} {=@show} on_close={@on_toggle} {=@placement}>
       <button
         class={"h-#{@height} w-#{@width} rounded flex items-center justify-center text-trunks hover:text-bulma #{@text_color} hover:#{@hover_bg_color} #{@class}"}
         title={@title}

--- a/lib/moon/components/popover.ex
+++ b/lib/moon/components/popover.ex
@@ -27,7 +27,7 @@ defmodule Moon.Components.Popover do
 
   prop(on_close, :event)
 
-  prop(id, :string)
+  prop(id, :string, required: true)
   prop(testid, :string)
 
   slot(default, required: true)

--- a/lib/moon/components/select/multi_select.ex
+++ b/lib/moon/components/select/multi_select.ex
@@ -142,7 +142,13 @@ defmodule Moon.Components.Select.MultiSelect do
   def render(assigns) do
     ~F"""
     <div>
-      <Popover placement={@popover_placement} show={@open} on_close="close" class={@popover_class}>
+      <Popover
+        id={"#{@id}-popover"}
+        placement={@popover_placement}
+        show={@open}
+        on_close="close"
+        class={@popover_class}
+      >
         {Phoenix.HTML.Form.multiple_select(@form, @field, SelectHelpers.get_formatted_options(@options),
           class: "hidden",
           id: @id

--- a/lib/moon/components/select/single_select.ex
+++ b/lib/moon/components/select/single_select.ex
@@ -47,7 +47,13 @@ defmodule Moon.Components.Select.SingleSelect do
           {@label}
         </FieldLabel>
       {/if}
-      <Popover placement={@popover_placement} show={@open} on_close="close" class={@popover_class}>
+      <Popover
+        id={"#{@id}-popover"}
+        placement={@popover_placement}
+        show={@open}
+        on_close="close"
+        class={@popover_class}
+      >
         {Phoenix.HTML.Form.select(
           @form,
           @field,

--- a/lib/moon_web/pages/components/dialog/popover_page.ex
+++ b/lib/moon_web/pages/components/dialog/popover_page.ex
@@ -13,7 +13,7 @@ defmodule MoonWeb.Pages.Components.Dialog.PopoverPage.PopoverExample do
   def render(assigns) do
     ~F"""
     <div>
-      <Popover show={@show} placement={@placement} on_close="toggle_show">
+      <Popover id="popover_id_1" show={@show} placement={@placement} on_close="toggle_show">
         <Button on_click="toggle_show" variant="primary">Click Me</Button>
 
         <:content>

--- a/lib/moon_web/pages/components/dropdown_menu_button_page.ex
+++ b/lib/moon_web/pages/components/dropdown_menu_button_page.ex
@@ -44,10 +44,15 @@ defmodule MoonWeb.Pages.Components.DropdownMenuButtonPage do
       <TopToDown>
         <Heading size={56} class="mb-4">DropdownMenuButton</Heading>
 
-        <ExampleAndCode id="dropdown_menu_button_1">
+        <ExampleAndCode id="dropdown_menu_button_example">
           <:example>
             <div class="flex justify-center">
-              <DropdownMenuButton show={@show_options} placement="bottom-end" on_toggle="toggle_options">
+              <DropdownMenuButton
+                id="dropdown_menu_button_1"
+                show={@show_options}
+                placement="bottom-end"
+                on_toggle="toggle_options"
+              >
                 <IconMore />
 
                 <:menu>
@@ -74,7 +79,7 @@ defmodule MoonWeb.Pages.Components.DropdownMenuButtonPage do
 
   def dropdown_menu_button_1_code do
     """
-      <DropdownMenuButton show={@show_options} placement="bottom-end" on_toggle="toggle_options">
+      <DropdownMenuButton id="dropdown_menu_button" show={@show_options} placement="bottom-end" on_toggle="toggle_options">
         <IconMore />
 
         <:menu>

--- a/lib/moon_web/pages/design/popover_page.ex
+++ b/lib/moon_web/pages/design/popover_page.ex
@@ -49,6 +49,13 @@ defmodule MoonWeb.Pages.Design.PopoverPage do
         title="Popover props"
         data={[
           %{
+            :name => ~c"id",
+            :type => ~c"string",
+            :required => ~c"Yes",
+            :default => ~c"-",
+            :description => ~c"Unique element's identifier"
+          },
+          %{
             :name => ~c"is_open",
             :type => ~c"boolean",
             :required => ~c"No",


### PR DESCRIPTION
Add id values for Popover components.
Related: https://github.com/coingaming/moon/pull/841

From LiveView docs:

https://hexdocs.pm/phoenix_live_view/js-interop.html
Note: when using phx-hook, a unique DOM ID must always be set.