### PR TITLE
feat: (table) use custom column name prefix in data-testid for <td>

### DIFF
--- a/lib/moon/design/table.ex
+++ b/lib/moon/design/table.ex
@@ -161,7 +161,8 @@ defmodule Moon.Design.Table do
             {#for {col, col_index} <- Enum.with_index(@cols)}
               <td
                 class={column_classes(col, col_index, @row_size, @is_cell_border, @cols_count)}
-                data-testid={"row-#{row_index}-col-#{col_index}"}
+                data-testid={(col[:tb_custom_testid_prefix] && "#{col[:tb_custom_testid_prefix]}-row-#{row_index}") ||
+                  "row-#{row_index}-col-#{col_index}"}
               >
                 <#slot {col} generator_value={item} />
               </td>
@@ -179,7 +180,8 @@ defmodule Moon.Design.Table do
             :for={{col, col_index} <- Enum.with_index(@footer_cols)}
             class={column_classes(col, col_index, @row_size, @is_cell_border, @footer_cols_count)}
             colspan={col[:colspan]}
-            data-testid={"footer-row-#{row_index}-col-#{col_index}"}
+            data-testid={(col[:tf_custom_testid_prefix] && "footer-#{col[:tf_custom_testid_prefix]}-row-#{row_index}") ||
+              "footer-row-#{row_index}-col-#{col_index}"}
           >
             <#slot {col} generator_value={item} />
           </td>

--- a/lib/moon/design/table/column.ex
+++ b/lib/moon/design/table/column.ex
@@ -13,4 +13,6 @@ defmodule Moon.Design.Table.Column do
   prop(width, :css_class)
   @doc "Simple additional css class, will be added to td tag only"
   prop(class, :css_class)
+  @doc "Uses a custom column name instead of a column index for the data-testid attribute in a <td> within the <tbody> tag."
+  prop(tb_custom_testid_prefix, :string)
 end

--- a/lib/moon/design/table/footer_column.ex
+++ b/lib/moon/design/table/footer_column.ex
@@ -7,7 +7,8 @@ defmodule Moon.Design.Table.FooterColumn do
   prop(width, :css_class)
   @doc "Simple additional css class, will be added to td tag only"
   prop(class, :css_class)
-
   @doc "it makes a cell span over multiple columns"
   prop(colspan, :integer, default: 1)
+  @doc "Uses a custom column name instead of a column index for the data-testid attribute in a <td> within the <tfooter> tag."
+  prop(tf_custom_testid_prefix, :string)
 end


### PR DESCRIPTION
 in <tbody> and <tfooter>